### PR TITLE
Field sensitivity with Spark

### DIFF
--- a/src/main/scala/br/unb/cic/soot/svfa/SVFA.scala
+++ b/src/main/scala/br/unb/cic/soot/svfa/SVFA.scala
@@ -42,7 +42,8 @@ abstract class SVFA {
 
   def afterGraphConstruction()
 
-  def callGraph(): CG = SPARK
+//  def callGraph(): CG = SPARK
+  def callGraph(): CG = SPARK_LIBRARY
 
   def buildSparseValueFlowGraph() {
     configureSoot()

--- a/src/main/scala/br/unb/cic/soot/svfa/jimple/JSVFA.scala
+++ b/src/main/scala/br/unb/cic/soot/svfa/jimple/JSVFA.scala
@@ -2,7 +2,7 @@ package br.unb.cic.soot.svfa.jimple
 
 import java.util
 import br.unb.cic.soot.svfa.jimple.rules.{ComposedRuleAction, DoNothing, MissingActiveBodyRule, NamedMethodRule, NativeRule, RuleAction}
-import br.unb.cic.soot.graph.{ContextSensitiveRegion, CallSiteCloseLabel, CallSiteLabel, CallSiteOpenLabel, FieldReference, FieldSensitiveLabel, FieldSensitiveLoadLabel, FieldSensitiveStoreLabel, GraphNode, SinkNode, SourceNode, StatementNode}
+import br.unb.cic.soot.graph.{ContextSensitiveRegion, CallSiteCloseLabel, CallSiteLabel, CallSiteOpenLabel, GraphNode, SinkNode, SourceNode, StatementNode}
 import br.unb.cic.soot.svfa.jimple.dsl.{DSL, LanguageParser}
 import br.unb.cic.soot.svfa.{SVFA, SourceSinkDef}
 import com.typesafe.scalalogging.LazyLogging
@@ -388,17 +388,6 @@ abstract class JSVFA extends SVFA with Analysis with FieldSensitiveness with Sou
         updateGraph(source, target)
         svg.getAdjacentNodes(source).get.foreach(s => updateGraph(s, target))
       })
-
-// TODO: Remove
-//      defs.getDefsOfAt(base.asInstanceOf[Local], stmt).forEach(source => {
-//        val sourceNode = createNode(method, source)
-//        val targetNode = createNode(method, stmt)
-//        val fsLoadLabel = createFieldSensitiveLoadLabel(ref)
-//        svg.addEdge(sourceNode, targetNode, fsLoadLabel)
-//      })
-//      if (isFieldSensitiveAnalysis()) {
-//        recursivePointsTo(Statement.convert(stmt), method)
-//      }
     }
   }
 
@@ -444,7 +433,6 @@ abstract class JSVFA extends SVFA with Analysis with FieldSensitiveness with Sou
       else {
         //        val allocationNodes = findAllocationSites(base)
 
-
 //        val allocationNodes = findAllocationSites(base, true, fieldRef.getField)
 //        if(!allocationNodes.isEmpty) {
 //          allocationNodes.foreach(targetNode => {
@@ -452,10 +440,6 @@ abstract class JSVFA extends SVFA with Analysis with FieldSensitiveness with Sou
           val source = createNode(method, sourceStmt)
           val target = createNode(method, targetStmt)
           updateGraph(source, target)
-// TODO: Remove
-//          if (isFieldSensitiveAnalysis()) {
-//            recursivePointsTo(Statement.convert(targetStmt), method)
-//          }
         })
         //          })
         //        }
@@ -535,10 +519,6 @@ abstract class JSVFA extends SVFA with Analysis with FieldSensitiveness with Sou
         val source = createNode(caller, sourceStmt)
         val target = createNode(caller, targetStmt)
         updateGraph(source, target)
-//
-//        if(isFieldSensitiveAnalysis()){
-//          recursivePointsTo(Statement.convert(sourceStmt), caller)
-//        }
       })
 
       if(local.getType.isInstanceOf[ArrayType]) {
@@ -564,46 +544,6 @@ abstract class JSVFA extends SVFA with Analysis with FieldSensitiveness with Sou
     }
   }
 
-  // TODO: Remove
-//  private def recursivePointsTo(stmt: Statement, caller: SootMethod): Unit = {
-//    if (stmt.isInstanceOf[AssignStmt]) {
-//      val assign = stmt.asInstanceOf[AssignStmt].stmt
-//
-//      // On store => q.f = p
-//      val leftOp = assign.getLeftOp
-//      if (leftOp.isInstanceOf[InstanceFieldRef]) {
-//        val fieldRef = leftOp.asInstanceOf[InstanceFieldRef]
-//        val ptsBase = findAllocationSites(fieldRef.getBase.asInstanceOf[Local])
-//        ptsBase.foreach(target => {
-//          val source = createNode(caller, stmt.base)
-////          updateGraph(source, target)
-//
-//          val fsStoreLabel = createFieldSensitiveStoreLabel(fieldRef)
-//          svg.addEdge(source, target, fsStoreLabel)
-//        })
-//      }
-//
-//      // On load => p = q.f
-//      val rightOp = assign.getRightOp
-//      if (rightOp.isInstanceOf[InstanceFieldRef]) {
-//        val fieldRef = rightOp.asInstanceOf[InstanceFieldRef]
-//        val ptsRight = findAllocationSites(rightOp.asInstanceOf[InstanceFieldRef].getBase.asInstanceOf[Local])
-//        ptsRight.foreach(source => {
-//          val target = createNode(caller, stmt.base)
-//          //          updateGraph(source, target)
-//
-//          val fsLoadLabel = createFieldSensitiveLoadLabel(fieldRef)
-//          svg.addEdge(source, target, fsLoadLabel)
-//
-////          svg.getAdjacentNodes(source).get.foreach(s => {
-//////            updateGraph(s, target)
-////              svg.addEdge(s, target, fsLoadLabel)
-////          })
-//        })
-//      }
-//    }
-//  }
-
   /*
    * creates a graph node from a sootMethod / sootUnit
    */
@@ -620,18 +560,6 @@ abstract class JSVFA extends SVFA with Analysis with FieldSensitiveness with Sou
     val statement = br.unb.cic.soot.graph.Statement(method.getDeclaringClass.toString, method.getSignature, stmt.toString, stmt.getJavaSourceStartLineNumber)
     CallSiteLabel(ContextSensitiveRegion(statement, callee.toString), CallSiteCloseLabel)
   }
-// TODO: Remove
-//  def createFieldSensitiveStoreLabel(fieldRef: InstanceFieldRef): FieldSensitiveLabel = {
-//    val declaringClass = fieldRef.getField.getDeclaringClass.getName
-//    val fieldName = fieldRef.getField.getName
-//    new FieldSensitiveLabel(FieldReference(declaringClass, fieldName), FieldSensitiveStoreLabel)
-//  }
-//
-//  def createFieldSensitiveLoadLabel(fieldRef: InstanceFieldRef): FieldSensitiveLabel = {
-//    val declaringClass = fieldRef.getField.getDeclaringClass.getName
-//    val fieldName = fieldRef.getField.getName
-//    new FieldSensitiveLabel(FieldReference(declaringClass, fieldName), FieldSensitiveLoadLabel)
-//  }
 
   def isThisInitStmt(expr: InvokeExpr, unit: soot.Unit) : Boolean =
     unit.isInstanceOf[IdentityStmt] && unit.asInstanceOf[IdentityStmt].getRightOp.isInstanceOf[ThisRef]

--- a/src/test/java/samples/fields/Container.java
+++ b/src/test/java/samples/fields/Container.java
@@ -1,0 +1,13 @@
+package samples.fields;
+
+public class Container {
+    public Foo Field;
+
+    void setField(Foo value) {
+        this.Field = value;
+    }
+
+    Foo getField() {
+        return this.Field;
+    }
+}

--- a/src/test/java/samples/fields/FieldSample01.java
+++ b/src/test/java/samples/fields/FieldSample01.java
@@ -1,0 +1,23 @@
+package samples.fields;
+
+public class FieldSample01 {
+    public void main() {
+        Foo x = source();
+
+        Container object = new Container();
+
+        object.Field = x; // Direct assignment of the Field (store)
+
+        Foo y = object.Field; // Direct access of the Field (load)
+
+        sink(y); // BAD
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample02.java
+++ b/src/test/java/samples/fields/FieldSample02.java
@@ -1,0 +1,26 @@
+package samples.fields;
+
+public class FieldSample02 {
+    public void main() {
+        Foo x = source();
+
+        Container object = new Container();
+
+        object.Field = x; // (store)
+
+        Foo z = new Foo();
+        object.Field = z; // overwrite the Field
+
+        Foo y = object.Field; // (load)
+
+        sink(y); // OK
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample03.java
+++ b/src/test/java/samples/fields/FieldSample03.java
@@ -1,0 +1,25 @@
+package samples.fields;
+
+public class FieldSample03 {
+    public class Bar {
+        Container obj;
+    }
+
+    public void main() {
+        Container object = new Container();
+        Bar bar = new Bar();
+
+        object.Field = source(); // SOURCE and (store)
+        bar.obj = object;
+
+        sink(bar.obj.Field); // SINK, BAD
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample04.java
+++ b/src/test/java/samples/fields/FieldSample04.java
@@ -1,0 +1,21 @@
+package samples.fields;
+
+public class FieldSample04 {
+    public void main() {
+        Foo x = source();
+
+        Container object = new Container();
+
+        object.Field = x; // Direct assignment of the Field (store)
+
+        sink(object); // Sink of base object BAD
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Container x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample05.java
+++ b/src/test/java/samples/fields/FieldSample05.java
@@ -1,0 +1,28 @@
+package samples.fields;
+
+public class FieldSample05 {
+    public void main() {
+        Foo x = source();
+        Foo y = new Foo(); // Clean
+
+        Container object1 = new Container();
+        Container object2 = new Container();
+
+        object1.Field = x;
+        object2.Field = y;
+
+        Foo tainted = object1.Field;
+        Foo clean = object2.Field;
+
+        sink(tainted); // BAD
+        sink(clean); // OK
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample06.java
+++ b/src/test/java/samples/fields/FieldSample06.java
@@ -1,0 +1,28 @@
+package samples.fields;
+
+public class FieldSample06 {
+    public void main() {
+        Foo x = source();
+        Foo y = new Foo(); // Clean
+
+        Container object1 = new Container();
+        Container object2 = new Container();
+
+        object1.setField(x);
+        object2.setField(y);
+
+        Foo tainted = object1.getField();
+        Foo clean = object2.getField();
+
+        sink(tainted); // BAD
+        sink(clean); // OK
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample07.java
+++ b/src/test/java/samples/fields/FieldSample07.java
@@ -1,0 +1,28 @@
+package samples.fields;
+
+public class FieldSample07 {
+    public void main() {
+        Foo x = source();
+
+        Container object = new Container();
+
+        object.Field = x; // (store)
+
+        if (false) {
+            Foo z = new Foo();
+            object.Field = z; // overwrite the Field
+        }
+
+        Foo y = object.Field; // (load)
+
+        sink(y); // BAD
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample08.java
+++ b/src/test/java/samples/fields/FieldSample08.java
@@ -1,0 +1,28 @@
+package samples.fields;
+
+public class FieldSample08 {
+    public void main() {
+        Foo x = source();
+
+        Container object = new Container();
+
+        object.Field = x; // (store)
+
+        if (true) {
+            Foo z = new Foo();
+            object.Field = z; // overwrite the Field
+        }
+
+        Foo y = object.Field; // (load)
+
+        sink(y); // OK
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample09.java
+++ b/src/test/java/samples/fields/FieldSample09.java
@@ -1,0 +1,33 @@
+package samples.fields;
+
+import java.util.Random;
+
+public class FieldSample09 {
+    public void main() {
+        Foo x = source();
+
+        Container object = new Container();
+
+        object.Field = x; // (store)
+
+        Random r = new Random();
+        boolean choice = r.nextBoolean();
+
+        if (choice) {
+            Foo z = new Foo();
+            object.Field = z; // overwrite the Field
+        }
+
+        Foo y = object.Field; // (load)
+
+        sink(y); // BAD
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample10.java
+++ b/src/test/java/samples/fields/FieldSample10.java
@@ -1,0 +1,20 @@
+package samples.fields;
+
+public class FieldSample10 {
+    int Field;
+
+    public void main() {
+        this.Field = source(); // SOURCE
+
+        // Sink of the field directly
+        sink(this.Field); // SINK, BAD
+    }
+
+    public int source() {
+        return 42;
+    }
+
+    public void sink(int x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample11.java
+++ b/src/test/java/samples/fields/FieldSample11.java
@@ -1,0 +1,21 @@
+package samples.fields;
+
+public class FieldSample11 {
+    int Field;
+
+    public void main() {
+        this.Field = source(); // SOURCE
+
+        this.Field = 10;
+
+        sink(this.Field); // SINK, OK
+    }
+
+    public int source() {
+        return 42;
+    }
+
+    public void sink(int x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample12.java
+++ b/src/test/java/samples/fields/FieldSample12.java
@@ -1,0 +1,21 @@
+package samples.fields;
+
+public class FieldSample12 {
+    Foo Field;
+
+    public void main() {
+        // The tainted object have a tainted field of a primitive type, created without 'new'
+        this.Field = source();
+
+        // Sink of the field directly
+        sink(this.Field); // SINK, BAD
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample13.java
+++ b/src/test/java/samples/fields/FieldSample13.java
@@ -1,0 +1,22 @@
+package samples.fields;
+
+public class FieldSample13 {
+    Foo Field;
+
+    public void main() {
+        this.Field = source();
+
+        this.Field = new Foo();
+
+        // Sink of the field directly
+        sink(this.Field); // SINK, OK
+    }
+
+    public Foo source() {
+        return new Foo();
+    }
+
+    public void sink(Foo x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample14.java
+++ b/src/test/java/samples/fields/FieldSample14.java
@@ -1,0 +1,21 @@
+package samples.fields;
+
+public class FieldSample14 {
+    String Field;
+
+    public void main() {
+        // The tainted object have a tainted field of a primitive type, created without 'new'
+        this.Field = source();
+
+        // Sink of the field directly
+        sink(this.Field); // SINK, BAD
+    }
+
+    public String source() {
+        return "secret";
+    }
+
+    public void sink(String x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/FieldSample15.java
+++ b/src/test/java/samples/fields/FieldSample15.java
@@ -1,0 +1,34 @@
+package samples.fields;
+
+public class FieldSample15 {
+    public class Bar {
+        String Field;
+
+        void setField(String x) {
+            this.Field = x;
+        }
+
+        String getField() {
+            return this.Field;
+        }
+    }
+
+
+    public void main() {
+        Bar object = new Bar();
+        object.setField(source()); // SOURCE
+
+        // Sink of the object without tainted field
+        String x = object.getField();
+
+        sink(x); // SINK, BAD
+    }
+
+    public String source() {
+        return "secret";
+    }
+
+    public void sink(String x) {
+        System.out.println(x);
+    }
+}

--- a/src/test/java/samples/fields/Foo.java
+++ b/src/test/java/samples/fields/Foo.java
@@ -1,0 +1,5 @@
+package samples.fields;
+
+public class Foo {
+
+}

--- a/src/test/scala/br/unb/cic/soot/FieldSamplesTestSuite.scala
+++ b/src/test/scala/br/unb/cic/soot/FieldSamplesTestSuite.scala
@@ -1,0 +1,163 @@
+package br.unb.cic.soot
+
+import br.unb.cic.soot.graph.{NodeType, _}
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import soot.jimple.{AssignStmt, InvokeExpr, InvokeStmt}
+
+class FieldSampleTest(var className: String = "", var mainMethod: String = "") extends JSVFATest {
+  override def getClassName(): String = className
+
+  override def getMainMethod(): String = mainMethod
+
+  override def runInFullSparsenessMode() = false
+
+  override def analyze(unit: soot.Unit): NodeType = {
+    unit match {
+      case invokeStmt: InvokeStmt =>
+        return analyzeInvokeStmt(invokeStmt.getInvokeExpr)
+      case assignStmt: AssignStmt =>
+        assignStmt.getRightOp match {
+          case invokeStmt: InvokeExpr =>
+            return analyzeInvokeStmt(invokeStmt)
+          case _ =>
+            return SimpleNode
+        }
+      case _ => return SimpleNode
+    }
+  }
+
+  def analyzeInvokeStmt(exp: InvokeExpr): NodeType = {
+    exp.getMethod.getName match {
+      case "source" => SourceNode
+      case "sink" => SinkNode
+      case _ => SimpleNode
+    }
+  }
+}
+
+
+class FieldSamplesTestSuite extends FunSuite with BeforeAndAfter {
+  test("in the class FieldSample01 we should detect 1 conflict in a direct sink of a tainted field") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample01", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // LIMITATION: Field overwrite is not supported
+  ignore("in the class FieldSample02 we should not detect any conflict because the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample02", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 0)
+  }
+
+  test("in the class FieldSample03 we should detect 1 conflict in a direct sink of a tainted field of a " +
+    "contained object") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample03", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // In the field sensitive analysis we not mark the whole object as tainted,
+  // in this case the sink of the object is not detected as a conflict
+  ignore("in the class FieldSample04 we should not detect any conflict because the contained tainted object " +
+    "and the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample04", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  test("in the class FieldSample05 we should detect 1 conflict in a direct sink of a object with a tainted field") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample05", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // LIMITATION: The Spark not support field sensitive analysis with context sensitivity
+  ignore("in the class FieldSample06 we should not detect any conflict because the contained tainted object " +
+    "and the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample06", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  test("in the class FieldSample07 we should detect 1 conflict in a direct sink of a object with a tainted field") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample07", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // LIMITATION: Field overwrite is not supported
+  ignore("in the class FieldSample08 we should not detect any conflict because the contained tainted object " +
+    "and the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample08", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 0)
+  }
+
+  test("in the class FieldSample09 we should not detect any conflict because the contained tainted object " +
+    "and the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample09", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // LIMITATION: Primitive type variables (like Int and String) created without 'new'
+  // are not detected by the Spark
+  ignore("in the class FieldSample10 we should detect 1 conflict in a direct sink of a tainted field") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample10", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  test("in the class FieldSample11 we should not detect any conflict because the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample11", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 0)
+  }
+
+  test("in the class FieldSample12 we should detect 1 conflict in a direct sink of a tainted field of a " +
+    "contained object") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample12", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // LIMITATION: Field overwrite is not supported
+  ignore("in the class FieldSample13 we should not detect any conflict because the contained tainted object " +
+    "and the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample13", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 0)
+  }
+
+  // LIMITATION: Primitive type variables (like Int and String) created without 'new'
+  // are not detected by the Spark
+  ignore("in the class FieldSample14 we should detect 1 conflict in a direct sink of a object with a tainted field") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample14", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+
+  // LIMITATION: The Spark not support field sensitive analysis with context sensitivity
+  ignore("in the class FieldSample15 we should not detect any conflict because the contained tainted object " +
+    "and the tainted field was override") {
+    val svfa = new FieldSampleTest("samples.fields.FieldSample15", "main")
+    svfa.buildSparseValueFlowGraph()
+//    println(svfa.svgToDotModel())
+    assert(svfa.reportConflicts().size == 1)
+  }
+}


### PR DESCRIPTION
# Field sensitivity with Spark

The current method to field sensitive analysis is too much complex, so we change
the field sensitive analysis to be based on Spark, a points-to analysis in Soot.

Changes:
 - Added the field sensitivity test suite in samples
 - Added the field sensitivity test cases
 - Removed the field sensitivity analysis based on base object.
 - Removed the nodes and edges related to field sensitivity of graph

Known limitations:
 - Field sensitivity to primitive types fields like Int and String.
 - Field overwrite
 - Field sensitivity with context sensitivity

Obs:
Field sensitivity require the SPARK_LIBRARY configuration.

The Spark not support field sensitive points-to analysis with context sensitivity,
this means that in cases with source values passed to object field by set like
methods, all objects of this type will have the same field pointed to the source
value. See the Basic17 test case of the Securibench.

## Broken test cases
### Securibench
 - Basic6   Why? Unknown
 - Basic16  Why? Spark not support field sensitive analysis with context sensitivity
 - Basic17  Why? Spark not support field sensitive analysis with context sensitivity
 - Basic22  Why? Unknown
 - Basic30  Why? Spark not support field sensitive analysis with context sensitivity

### Testsuite
 - Basic16  Why? Spark not support field sensitive analysis with context sensitivity
 - Hashmap  Why? Unknown